### PR TITLE
Little speed improvement

### DIFF
--- a/src/Clue/Redis/Protocol/Model/BulkReply.php
+++ b/src/Clue/Redis/Protocol/Model/BulkReply.php
@@ -12,7 +12,7 @@ class BulkReply implements ModelInterface
     /**
      * create bulk reply (string reply)
      *
-     * @param string|null $data
+     * @param string|null $value
      */
     public function __construct($value)
     {

--- a/src/Clue/Redis/Protocol/Model/ErrorReply.php
+++ b/src/Clue/Redis/Protocol/Model/ErrorReply.php
@@ -15,7 +15,6 @@ class ErrorReply extends Exception implements ModelInterface
      * create error status reply (single line error message)
      *
      * @param string|ErrorReplyException $message
-     * @return string
      */
     public function __construct($message, $code = 0, $previous = null)
     {

--- a/src/Clue/Redis/Protocol/Model/IntegerReply.php
+++ b/src/Clue/Redis/Protocol/Model/IntegerReply.php
@@ -12,7 +12,7 @@ class IntegerReply implements ModelInterface
     /**
      * create integer reply
      *
-     * @param int $data
+     * @param int $value
      */
     public function __construct($value)
     {

--- a/src/Clue/Redis/Protocol/Model/StatusReply.php
+++ b/src/Clue/Redis/Protocol/Model/StatusReply.php
@@ -15,7 +15,6 @@ class StatusReply implements ModelInterface
      * create status reply (single line message)
      *
      * @param string|Status $message
-     * @return string
      */
     public function __construct($message)
     {

--- a/src/Clue/Redis/Protocol/Parser/ResponseParser.php
+++ b/src/Clue/Redis/Protocol/Parser/ResponseParser.php
@@ -96,7 +96,7 @@ class ResponseParser implements ParserInterface
         if ($reply === null) {
             return null;
         }
-        switch (substr($reply, 0, 1)) {
+        switch ($reply[0]) {
             /* Error reply */
             case '-':
                 $response = new ErrorReply(substr($reply, 1));


### PR DESCRIPTION
Before : 

```
➜  php-redis-protocol (master) ✗ php example/perf.php 1000000
benchmarking 1000000 messages (chunksize of 4096 bytes)
2s for serialization
11.836s for parsing
➜  php-redis-protocol (master) ✗ php example/perf.php 1000000
benchmarking 1000000 messages (chunksize of 4096 bytes)
2.162s for serialization
11.803s for parsing
```

After : 

```
➜  php-redis-protocol (master) ✗ php example/perf.php 1000000
benchmarking 1000000 messages (chunksize of 4096 bytes)
2.022s for serialization
11.211s for parsing
➜  php-redis-protocol (master) ✗ php example/perf.php 1000000
benchmarking 1000000 messages (chunksize of 4096 bytes)
2.047s for serialization
11.109s for parsing
```
