### PR TITLE
Extend SerializerInterface and RecursiveSerializer in order to suppor…

### DIFF
--- a/src/Clue/Redis/Protocol/Serializer/SerializerInterface.php
+++ b/src/Clue/Redis/Protocol/Serializer/SerializerInterface.php
@@ -21,10 +21,11 @@ interface SerializerInterface
      *
      * @param string $command
      * @param array $args
+     * @param array $options
      * @return string
      * @see self::createRequestMessage()
      */
-    public function getRequestMessage($command, array $args = array());
+    public function getRequestMessage($command, array $args = array(), array $options = array());
 
     /**
      * create a unified request protocol message model


### PR DESCRIPTION
Extend SerializerInterface and RecursiveSerializer in order to support redis options

- remove unused use statement in RecursiveSerializer
- change SerializerInterface to take 'options' as an optional parameter
- change getRequestMessage in RecursiveSerializer in order to support 'options' like 'ex', 'nx', 'xx' for 'set' operation without breaking the redis protocol logic