### PR TITLE
Use GitHub actions for continuous integration (CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  PHPUnit:
+    name: PHPUnit (PHP ${{ matrix.php }})
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        php:
+          - 5.4
+          - 5.3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: xdebug
+      - run: composer install
+      - run: vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: php
-php:
-  - 5.4
-  - 5.3
-before_script:
-  - composer install --dev --prefer-source --no-interaction
-script:
-  - phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # clue/redis-protocol [![Build Status](https://travis-ci.org/clue/php-redis-protocol.png?branch=master)](https://travis-ci.org/clue/php-redis-protocol)
 
+[![CI status](https://github.com/clue/php-redis-protocol/actions/workflows/ci.yml/badge.svg)](https://github.com/clue/php-redis-protocol/actions)
+[![installs on Packagist](https://img.shields.io/packagist/dt/clue/redis-protocol?color=blue&label=installs%20on%20Packagist)](https://packagist.org/packages/clue/redis-protocol)
+
 A streaming redis protocol parser and serializer written in PHP 
 
 This parser and serializer implementation allows you to parse redis protocol

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,17 @@
     "require": {
         "php": ">=5.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8.36"
+    },
     "autoload": {
-        "psr-0": { "Clue\\Redis\\Protocol": "src" }
+        "psr-0": {
+            "Clue\\Redis\\Protocol": "src/"
+        }
+    }    ,
+    "autoload-dev": {
+        "psr-0": {
+            "": "tests/"
+        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="tests/bootstrap.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
->
+<!-- PHPUnit configuration file with old format for legacy PHPUnit -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
     <testsuites>
         <testsuite name="Redis Protocol Test Suite">
             <directory>./tests/</directory>
@@ -16,4 +15,7 @@
             <directory>./src/</directory>
         </whitelist>
     </filter>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
 </phpunit>

--- a/tests/Parser/ResponseParserTest.php
+++ b/tests/Parser/ResponseParserTest.php
@@ -2,7 +2,7 @@
 
 use Clue\Redis\Protocol\Parser\ResponseParser;
 
-class RecursiveParserTest extends AbstractParserTest
+class ResponseParserTest extends AbstractParserTest
 {
     protected function createParser()
     {

--- a/tests/Serializer/AbstractSerializerTest.php
+++ b/tests/Serializer/AbstractSerializerTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Clue\Redis\Protocol\Serializer\SerializerInterface;
-use Clue\Redis\Protocol\Model\Status;
-use Clue\Redis\Protocol\Model\ErrorReplyException;
 //use Exception;
 
 abstract class AbstractSerializerTest extends TestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,5 @@
+<?php
+
+class TestCase extends PHPUnit_Framework_TestCase
+{
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,0 @@
-<?php
-
-(include_once __DIR__ . '/../vendor/autoload.php') OR die(PHP_EOL . 'ERROR: composer autoloader not found, run "composer install" or see README for instructions' . PHP_EOL);
-
-class TestCase extends PHPUnit_Framework_TestCase
-{
-}


### PR DESCRIPTION
This pull requests updates this project to use GitHub actions for continuous integration instead of travis. I tried to avoid tackling too many topics at once in here, so I'll look into supporting newer PHP versions and updating the documentation in a follow up PR. This is an internal refactoring only and shouldn't have any impact on projects using this as a dependency.

I also saw that #10 and #14 were working on similar topics, so my pull request here will supersedes them both and closes them once this PR gets merged.

Closes #14